### PR TITLE
Fix backlight key description

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ SSDT-PLUG-ALT.aml
 - Format the drive as `APFS` and `GUID Partition Table / GPT`
 - Map your USB ports prior to installing macOS³ for a painless install. You **will** reget it if you don't. You can use [USBToolBox](https://github.com/USBToolBox/tool) to do that. You *will* need a second kext that goes along with it for it to work. [Repo here.](https://github.com/USBToolBox/kext). USBToolBox will not work without this kext. 
 - AppleTV and other DRM protected services may not work.
-- Control keyboard backlight with left `ctrl` + left `alt` and `<` `>`. 
-    - `<` to decrease, `>` to increase.
+- Control keyboard backlight with left `ctrl` + left `alt` and `,` `.`. 
+    - `,` to decrease, `.` to increase.
 - To fix  battery life, use CPUFriend to tweak power settings. 
 - To hide the OpenCore boot menu, set `ShowPicker` to `False` in `Misc` ->` Boot` -> `ShowPicker`
 - `AppleXcpmCfgLock` and `DisableIOMapper` can be enabled or disabled. There is no difference.


### PR DESCRIPTION
https://github.com/meghan06/ChromebookPS2 states that

>Keyboard backlight can be controlled with `left ctrl` + `left alt` + comma (`,`) and period (`.`) keys.
